### PR TITLE
Fix failure to reconnect on remote disconnect

### DIFF
--- a/pymee/__init__.py
+++ b/pymee/__init__.py
@@ -184,7 +184,10 @@ class Homee:
 
                     except websockets.exceptions.ConnectionClosed as e:
                         self.connected = False
-                        ws.abort_pings()
+                        try:
+                            ws.abort_pings()
+                        except Exception as e:
+                            await self._ws_on_error(e)
                         await self.on_disconnected()
         except Exception as e:
             await self._ws_on_error(e)


### PR DESCRIPTION
When the connection drops, the pong_waiter task can be already done when ws.abort_pings() is called, leading to an InvalidStateError as abort_pings() is unconditionally calling set_exception on the pong_waiter. If that exception is not caught, we're falling outside the recovery loop and do not reconnect. To fix this, put a try block around ws.abort_pings().