### PR TITLE
Fix "'list' object is not an iterator"

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ remove_listener = node.add_on_changed_listener(my_node_handler)
 remove_listener()
 ```
 
+To manually request updates from Homee, you can use the following functions:
+```python
+homee.update_node(self, nodeId: int)
+"""Request current data for a node."""
+
+homee.update_attribute(self, nodeId: int, attributeId: int)
+"""Request current data for an attribute"""
+```
+
 ### More examples
 
 Example implementation that dumps all info into a json file and logs whenever a light is turned on or off:

--- a/pymee/__init__.py
+++ b/pymee/__init__.py
@@ -433,11 +433,16 @@ class Homee:
         await self.send(
             f"PUT:/nodes/{deviceId}/attributes/{attributeId}?target_value={value}"
         )
+   
+    async def update_node(self, nodeId: int):
+        """Request current data for a node."""
+        _LOGGER.info(f"Request current data for node {nodeId}")
+        await self.send(f"GET:/nodes/{nodeId}/")
 
-    async def get_attribute(self, deviceId: int, attributeId: int):
-        """Get the current state of an attribute"""
-        _LOGGER.info(f'request attribute {attributeId} of device {deviceId}')
-        await self.send(f"GET:/nodes/{deviceId}/attributes/{attributeId}")
+    async def update_attribute(self, nodeId: int, attributeId: int):
+        """Request current data for an attribute"""
+        _LOGGER.info(f'request current data for attribute {attributeId} of device {nodeId}')
+        await self.send(f"GET:/nodes/{nodeId}/attributes/{attributeId}")
 
     async def play_homeegram(self, homeegramId: int):
         """Invoke a homeegram."""


### PR DESCRIPTION
This patch catches the above error, which occurs in the _update_or_create_relationships function.

I'm not yet sure, why it happens, because the data I logged IS iterable and the for/in call should not fail.
I have to investigate further and now the relationships may not be updated, of which I don't know which side-effects it has.
But with this, the connection stays intact which should be more important for the users.

Also some deprecations are fixed and the readme is updated for the functions added lately.