### PR TITLE
Fix automatic reconnection

### DIFF
--- a/pymee/__init__.py
+++ b/pymee/__init__.py
@@ -252,7 +252,7 @@ class Homee:
         """Start a reconnection attempt."""
 
         _LOGGER.info(
-            f"Attempting to reconnect in {self.reconnectInterval * self.retries} seconds..."
+            "Attempting to reconnect in %s seconds", self.reconnectInterval * self.retries
         )
 
         await asyncio.sleep(self.reconnectInterval * self.retries)
@@ -271,7 +271,7 @@ class Homee:
         try:
             msgType = list(msg)[0]
         except:
-            _LOGGER.warning(f"Invalid message: {msg}")
+            _LOGGER.warning("Invalid message: %s", msg)
             await self.on_error()
             return
 
@@ -317,14 +317,14 @@ class Homee:
         elif msgType == "relationship":
             self._update_or_create_relationship(msg["relationship"])
         else:
-            _LOGGER.info(f"Unknown/Unsupported message type: {msgType}")
+            _LOGGER.info("Unknown/Unsupported message type: %s", msgType)
 
         await self.on_message(msg)
 
     async def _handle_attribute_change(self, attribute_data: dict):
         """Internal handleling of an attribute changed message."""
 
-        _LOGGER.info(f"Updating attribute {attribute_data['id']}")
+        _LOGGER.info("Updating attribute %s", attribute_data['id'])
 
               
         attrNodeId = attribute_data["node_id"]
@@ -414,7 +414,7 @@ class Homee:
         """Set the target value of an attribute of a device."""
 
         _LOGGER.info(
-            f"Set value: Device: {deviceId} Attribute: {attributeId} To: {value}"
+            "Set value: Device: %s Attribute: %s To: %s", deviceId, attributeId, value
         )
         await self.send(
             f"PUT:/nodes/{deviceId}/attributes/{attributeId}?target_value={value}"
@@ -422,13 +422,13 @@ class Homee:
 
     async def update_node(self, nodeId: int):
         """Request current data for a node."""
-        _LOGGER.info(f"Request current data for node {nodeId}")
+        _LOGGER.info("Request current data for node %s", nodeId)
         await self.send(f"GET:/nodes/{nodeId}/")
 
     async def update_attribute(self, nodeId: int, attributeId: int):
         """Request current data for an attribute"""
         _LOGGER.info(
-            f"request current data for attribute {attributeId} of device {nodeId}"
+            "request current data for attribute %s of device %s", attributeId, nodeId
         )
         await self.send(f"GET:/nodes/{nodeId}/attributes/{attributeId}")
 
@@ -459,23 +459,25 @@ class Homee:
 
     async def on_reconnect(self):
         """Called right before a reconnection attempt is started."""
-        _LOGGER.info("Reconnecting")
+        _LOGGER.info("Homee %s Reconnecting", self.device)
 
     async def on_max_retries(self):
         """Called if the maximum amount of retries was reached."""
-        _LOGGER.warning(f"Could not reconnect after {self.maxRetries} retries.")
+        _LOGGER.warning("Could not reconnect Homee %s after %s retries.", self.device, self.maxRetries)
 
     async def on_connected(self):
         """Called once the websocket connection has been established."""
+        If self.retries > 0:
+            _LOGGER.warning("Homee %s Reconnected after %s retries", self.device, self.retries)
 
     async def on_disconnected(self):
         """Called after the websocket connection has been closed."""
         if not self.shouldClose:
-            _LOGGER.info("Disconnected")
+            _LOGGER.warning("Homee %s Disconnected", self.device)
 
     async def on_error(self, error: str = None):
         """Called after an error has occurred."""
-        _LOGGER.error(f"An error occurred: {error}")
+        _LOGGER.error("An error occurred: %s", error)
     
     async def on_message(self, msg: dict):
         """Called when the websocket receives a message. The message is automatically parsed from json into a dictionary."""

--- a/pymee/__init__.py
+++ b/pymee/__init__.py
@@ -467,7 +467,7 @@ class Homee:
 
     async def on_connected(self):
         """Called once the websocket connection has been established."""
-        If self.retries > 0:
+        if self.retries > 0:
             _LOGGER.warning("Homee %s Reconnected after %s retries", self.device, self.retries)
 
     async def on_disconnected(self):

--- a/pymee/__init__.py
+++ b/pymee/__init__.py
@@ -153,9 +153,6 @@ class Homee:
             ) as ws:
                 await self._ws_on_open()
 
-                # Start Ping
-                asyncio.create_task(self._ws_ping_handler(ws))
-
                 while (not self.shouldClose) and self.connected:
                     try:
                         receive_task = asyncio.ensure_future(
@@ -209,19 +206,6 @@ class Homee:
             if not self.shouldClose:
                 self.connected = False
                 raise e
-
-    async def _ws_ping_handler(self, ws: websockets.WebSocketClientProtocol):
-        if self.pingInterval <= 0:
-            return
-
-        while self.connected and not self.shouldClose and ws.open:
-            _LOGGER.info("PING!")
-            try:
-                await ws.ping()
-            except websockets.exceptions.ConnectionClosed as e:
-                self.connected = False
-                await self.on_disconnected()
-            await asyncio.sleep(self.pingInterval)
 
     async def _ws_on_open(self):
         """Websocket on_open callback."""

--- a/pymee/model.py
+++ b/pymee/model.py
@@ -1,4 +1,4 @@
-from typing import Callable, List
+from collections.abc import Callable
 from urllib.parse import unquote
 
 
@@ -11,48 +11,49 @@ class HomeeAttributeOptions:
         """List (int) of attribute types that this attribute can observe."""
         if "can_observe" in self._data:
             return self._data["can_observe"]
-        else:
-            return []
+
+        return []
 
     @property
     def observes(self) -> list:
         """List (int) of attribute ids that this attribute observes."""
         if "observes" in self._data:
             return self._data["observes"]
-        else:
-            return []
+
+        return []
 
     @property
     def observed_by(self) -> list:
         """List (int) of attribute ids that observe this attribute."""
         if "observed_by" in self._data:
             return self._data["observed_by"]
-        else:
-            return []
+
+        return []
 
     @property
     def automations(self) -> list:
         """List (str) of automations for thie attribute."""
         if "automations" in self._data:
             return self._data["automations"]
-        else:
-            return []
+
+        return []
 
     @property
-    def history(self) -> List[dict]:
+    def history(self) -> list[dict]:
         """History data for the attribute. {'day': int, 'week': int, 'month': int, 'stepped': bool}"""
         if "history" in self._data:
             return self._data["history"]
-        else:
-            return {}
+
+        return {}
 
     @property
     def reverse_control_ui(self) -> bool:
         """Do up/down controls work in opposite direction?"""
         if "reverse_control_ui" in self._data:
             return self._data["reverse_control_ui"]
-        else:
-            return False
+
+        return False
+
 
 class HomeeAttribute:
     def __init__(self, data: dict) -> None:
@@ -130,7 +131,7 @@ class HomeeAttribute:
 
     @property
     def changed_by(self) -> int:
-        """How the attribute was changed. Compare with const.AttributeChangedBy"""
+        """How the attribute was changed. Compare with const.AttributeChangedBy."""
         return self._data["changed_by"]
 
     @property
@@ -162,13 +163,13 @@ class HomeeAttribute:
 class HomeeNode:
     def __init__(self, data: dict) -> None:
         self._data = data
-        self.attributes: List[HomeeAttribute] = []
+        self.attributes: list[HomeeAttribute] = []
         for a in self.attributes_raw:
             self.attributes.append(HomeeAttribute(a))
         self._attribute_map: dict = None
         self._remap_attributes()
         self._onChangedListeners = []
-        self.groups: List[HomeeGroup] = []
+        self.groups: list[HomeeGroup] = []
 
     @property
     def id(self) -> int:
@@ -247,9 +248,9 @@ class HomeeNode:
     @property
     def attribute_map(self) -> dict | None:
         return self._attribute_map
-    
+
     @property
-    def attributes_raw(self) -> List[dict]:
+    def attributes_raw(self) -> list[dict]:
         return self._data["attributes"]
 
     def get_attribute_index(self, attributeId: int) -> int:
@@ -274,18 +275,18 @@ class HomeeNode:
 
     def _update_attribute(self, attribute_data: dict):
         attribute = self.get_attribute_by_id(attribute_data["id"])
-        if attribute != None:
+        if attribute is not None:
             attribute._data = attribute_data
             result = [
                 listener(self, attribute) for listener in self._onChangedListeners
             ]
 
-    def _update_attributes(self, attributes: List[dict]):
+    def _update_attributes(self, attributes: list[dict]):
         for attr in attributes:
             self._update_attribute(attr)
 
     def _remap_attributes(self):
-        if self._attribute_map != None:
+        if self._attribute_map is not None:
             self._attribute_map.clear()
         else:
             self._attribute_map = {}
@@ -296,7 +297,7 @@ class HomeeNode:
 class HomeeGroup:
     def __init__(self, data) -> None:
         self._data = data
-        self.nodes: List[HomeeNode] = []
+        self.nodes: list[HomeeNode] = []
 
     @property
     def id(self) -> int:
@@ -444,7 +445,7 @@ class HomeeSettings:
         return self._data["lan_ip_address"]
 
     @property
-    def available_ssids(self) -> List[str]:
+    def available_ssids(self) -> list[str]:
         return self._data["available_ssids"]
 
     @property
@@ -464,11 +465,11 @@ class HomeeSettings:
         return self._data["uid"]
 
     @property
-    def cubes(self) -> List[dict]:
+    def cubes(self) -> list[dict]:
         return self._data["cubes"]
 
     @property
-    def extensions(self) -> List[dict]:
+    def extensions(self) -> list[dict]:
         return self._data["extensions"]
 
 

--- a/pymee/model.py
+++ b/pymee/model.py
@@ -245,6 +245,10 @@ class HomeeNode:
         return self._data["security"]
 
     @property
+    def attribute_map(self) -> dict | None:
+        return self._attribute_map
+    
+    @property
     def attributes_raw(self) -> List[dict]:
         return self._data["attributes"]
 


### PR DESCRIPTION
This pull request fixes the following:
- automatic reconnects, which were borken due to uncaught exceptions.
- change logging, so disconnect and reconnect is logged once to fulfill [HA integration quality scale](https://developers.home-assistant.io/docs/integration_quality_scale_index/#silver-)
- change log-messages to fprint style strings du to [HA style guide](https://developers.home-assistant.io/docs/development_guidelines/#use-new-style-string-formatting)
- tackle some deprecations
- expose attribute_map as a public property to get rid of some lint warnings in HA homee integration